### PR TITLE
Bump tailwindcss to 2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,16 +9,20 @@
     "devDependencies": {
         "laravel-mix": "^6.0.18",
         "postcss": "^8.2.10",
-        "tailwindcss": "^1.9.6",
+        "resolve-url-loader": "^3.1.2",
+        "sw-precache-webpack-plugin": "^1.0.0",
+        "tailwindcss": "^2.0.1",
         "vue-loader": "^15.9.6",
         "vue-template-compiler": "^2.6.12"
     },
     "dependencies": {
         "@tobiasthaden/tap": "^1.0.0",
+        "autoprefixer": "^10.0.2",
         "axios": "^0.21.1",
         "cookieguard": "^0.2.1",
         "gsap": "^3.6.1",
         "lottie-web": "^5.7.8",
+        "postcss": "^8.1.8",
         "turbolinks": "^5.2.0",
         "vue": "^2.6.12",
         "waypoints": "^4.0.1"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,9 +2,6 @@ module.exports = {
     prefix: "",
     important: false,
     separator: ":",
-    future: {
-        removeDeprecatedGapUtilities: true,
-    },
     purge: {
         mode: 'layers',
         layers: ['utilities'],
@@ -39,12 +36,12 @@ module.exports = {
             black: "#000000",
             white: "#ffffff",
             gray: {
-                default: "#F4F4F4",
+                DEFAULT: "#F4F4F4",
                 mid: "#303030",
             },
             green: {
                 soft: "#E9F9E3",
-                default: "#00ff00",
+                DEFAULT: "#00ff00",
             },
         },
         spacing: {
@@ -100,18 +97,18 @@ module.exports = {
         },
         borderColor: theme => ({
             ...theme("colors"),
-            default: theme("colors.gray.300", "currentColor"),
+            DEFAULT: theme("colors.gray.300", "currentColor"),
         }),
         borderRadius: {
             none: "0",
             sm: "0.125rem",
-            default: "0.25rem",
+            DEFAULT: "0.25rem",
             md: "0.375rem",
             lg: "0.5rem",
             full: "9999px",
         },
         borderWidth: {
-            default: "1px",
+            DEFAULT: "1px",
             "0": "0",
             "2": "2px",
             "4": "4px",
@@ -120,7 +117,7 @@ module.exports = {
         boxShadow: {
             xs: "0 0 0 1px rgba(0, 0, 0, 0.05)",
             sm: "0 1px 2px 0 rgba(0, 0, 0, 0.05)",
-            default:
+            DEFAULT:
                 "0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06)",
             md:
                 "0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)",
@@ -135,7 +132,7 @@ module.exports = {
         container: {},
         cursor: {
             auto: "auto",
-            default: "default",
+            DEFAULT: "DEFAULT",
             pointer: "pointer",
             wait: "wait",
             text: "text",
@@ -155,11 +152,11 @@ module.exports = {
         },
         flexGrow: {
             "0": "0",
-            default: "1",
+            DEFAULT: "1",
         },
         flexShrink: {
             "0": "0",
-            default: "1",
+            DEFAULT: "1",
         },
         fontFamily: {
             hero: ["Grtsk Tera", "sans-serif"],
@@ -502,7 +499,7 @@ module.exports = {
         transitionProperty: {
             none: "none",
             all: "all",
-            default:
+            DEFAULT:
                 "background-color, border-color, color, fill, stroke, opacity, box-shadow, transform",
             colors: "background-color, border-color, color, fill, stroke",
             opacity: "opacity",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -132,7 +132,7 @@ module.exports = {
         container: {},
         cursor: {
             auto: "auto",
-            DEFAULT: "DEFAULT",
+            DEFAULT: "default",
             pointer: "pointer",
             wait: "wait",
             text: "text",


### PR DESCRIPTION
This PR totally removes IE11 support. 

Here is the new list of supported browsers:
- chrome 86
- chrome 85
- chrome 84
- edge 86
- edge 85
- firefox 82
- firefox 81
- iOS safari 14
- iOS safari 13.4-13.7
- opera mobile 59
- opera 72
- opera 71
- safari 14
- samsung 12.0
- samsung 11.1-11.2

:bowtie: